### PR TITLE
Визуализация на definitionList блок

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,9 @@
         .content-view h2 { font-family: var(--font-sans); font-size: 2em; margin: 2em 0 1em 0; line-height: 1.2; }
         .content-view h3 { font-family: var(--font-sans); font-size: 1.5em; margin: 1.5em 0 0.8em 0; line-height: 1.3; }
         .content-view p { margin-bottom: 1.2em; }
+        .content-view dl { margin: 1.5em 0; }
+        .content-view dt { font-weight: bold; }
+        .content-view dd { margin: 0 0 0.8em 1em; }
         .content-view blockquote { margin: 2em 0; padding-left: 1.5em; border-left: 2px solid var(--accent-color); font-style: italic; }
         .content-view blockquote cite { display: block; margin-top: 0.5em; font-style: normal; }
         .content-view ::selection { background-color: var(--highlight-color); }
@@ -156,7 +159,17 @@
                             "chapterId": "ch14", "chapterTitle": "Несъзнателните модели",
                             "epigraph": { "text": "Докато не направиш несъзнателното съзнателно, то ще управлява живота ти и ти ще го наричаш съдба.", "source": "Карл Юнг" },
                             "contentBlocks": [
-                                { "type": "paragraph", "content": "Дигиталният одит ви даде моментна снимка. Но истинската сила се крие в разпознаването на *моделите*, които се повтарят във времето – циклите, в които попадаме отново и отново, често без дори да го осъзнаваме." }
+                                { "type": "paragraph", "content": "Дигиталният одит ви даде моментна снимка. Но истинската сила се крие в разпознаването на *моделите*, които се повтарят във времето – циклите, в които попадаме отново и отново, често без дори да го осъзнаваме." },
+                                { "type": "heading", "level": 3, "content": "Специализацията: Разделянето на дигиталното „Аз“" },
+                                { "type": "paragraph", "content": "Светът стана твърде голям, за да се побере в една платформа. Така започна ерата на специализацията, в която нашето дигитално „Аз“ се фрагментира. Ще разгледаме тези платформи в детайли по-късно, но ето кратко резюме:" },
+                                { "type": "definitionList",
+                                  "items": [
+                                      { "term": "Instagram", "definition": "Театърът на перфектната естетика. Нашето лъскаво, филтрирано „Аз“." },
+                                      { "term": "X (Twitter)", "definition": "Световният колизеум на мненията. Нашето идейно „Аз“." },
+                                      { "term": "TikTok", "definition": "Безкрайната допаминова въртележка. Нашето импулсивно „Аз“." },
+                                      { "term": "LinkedIn", "definition": "Корпоративният маскен бал. Нашето професионално „Аз“." }
+                                  ]
+                                }
                             ]
                         }
                     ]
@@ -298,6 +311,11 @@
                                 <p class="instructions">${block.instructions}</p>
                                 <textarea data-exercise-id="${block.exerciseId}" placeholder="${block.fields[0].placeholder}">${this.state.exerciseAnswers[block.exerciseId] || ''}</textarea>
                             </div>`;
+                            break;
+                        case 'definitionList':
+                            html += '<dl>' +
+                                block.items.map(it => `<dt>${it.term}</dt><dd>${it.definition}</dd>`).join('') +
+                                '</dl>';
                             break;
                     }
                 });


### PR DESCRIPTION
## Summary
- добавих `definitionList` case в JS за рендиране на главите
- стилизирах `<dl>`, `<dt>` и `<dd>`
- включих примерния блок от *jsonhowto* в съдържанието

## Testing
- `node - <<'NODE'
const items = [
  {term: 'Instagram', definition: 'Театърът на перфектната естетика. Нашето лъскаво, филтрирано „Аз“."'},
  {term: 'X (Twitter)', definition: 'Световният колизеум на мненията. Нашето идейно „Аз".'}
];
const html='<dl>'+items.map(it=>`<dt>${it.term}</dt><dd>${it.definition}</dd>`).join('')+'</dl>';
console.log(html);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_687589cd9550832698a0c617cf0180cb